### PR TITLE
0.7 cli seticore ram

### DIFF
--- a/apps/blade-cli/include/blade-cli/telescopes/ata/config.hh
+++ b/apps/blade-cli/include/blade-cli/telescopes/ata/config.hh
@@ -56,6 +56,9 @@ typedef struct {
     BOOL driftRateZeroExcluded;
     BOOL incoherentBeamEnabled;
     BOOL progressBarDisabled;
+    U64 hitsGroupingMargin;
+    BOOL produceDebugHits;
+    F64 stampFrequencyMarginHz;
 } Config;
 
 }  // namespace Blade::CLI::Telecopes::ATA

--- a/apps/blade-cli/include/blade-cli/telescopes/ata/config.hh
+++ b/apps/blade-cli/include/blade-cli/telescopes/ata/config.hh
@@ -56,7 +56,7 @@ typedef struct {
     BOOL driftRateZeroExcluded;
     BOOL incoherentBeamEnabled;
     BOOL progressBarDisabled;
-    U64 hitsGroupingMargin;
+    I64 hitsGroupingMargin;
     BOOL produceDebugHits;
     F64 stampFrequencyMarginHz;
 } Config;

--- a/apps/blade-cli/include/blade-cli/telescopes/ata/config.hh
+++ b/apps/blade-cli/include/blade-cli/telescopes/ata/config.hh
@@ -60,6 +60,7 @@ typedef struct {
     BOOL produceDebugHits;
     F64 stampFrequencyMarginHz;
     BOOL phasorNegateDelays;
+    U64 inputGuppiFileLimit;
 } Config;
 
 }  // namespace Blade::CLI::Telecopes::ATA

--- a/apps/blade-cli/include/blade-cli/telescopes/ata/config.hh
+++ b/apps/blade-cli/include/blade-cli/telescopes/ata/config.hh
@@ -59,6 +59,7 @@ typedef struct {
     I64 hitsGroupingMargin;
     BOOL produceDebugHits;
     F64 stampFrequencyMarginHz;
+    BOOL phasorNegateDelays;
 } Config;
 
 }  // namespace Blade::CLI::Telecopes::ATA

--- a/apps/blade-cli/include/blade-cli/telescopes/ata/mode_b.hh
+++ b/apps/blade-cli/include/blade-cli/telescopes/ata/mode_b.hh
@@ -37,6 +37,7 @@ inline const Result ModeB(const Config& config) {
         .stepNumberOfTimeSamples = config.preBeamformerChannelizerRate,
         .stepNumberOfFrequencyChannels = config.stepNumberOfFrequencyChannels,
         .numberOfTimeSampleStepsBeforeFrequencyChannelStep = config.stepNumberOfTimeSamples,
+        .numberOfGuppiFilesLimit = config.inputGuppiFileLimit,
     };
 
     auto readerRunner = Runner<Reader>::New(1, readerConfig, false);

--- a/apps/blade-cli/include/blade-cli/telescopes/ata/mode_b.hh
+++ b/apps/blade-cli/include/blade-cli/telescopes/ata/mode_b.hh
@@ -98,6 +98,7 @@ inline const Result ModeB(const Config& config) {
         .phasorAntennaCoefficients = reader.getAntennaCoefficients(readerTotalOutputDims.numberOfFrequencyChannels(), reader.getChannelStartIndex()),
         .phasorBeamCoordinates = reader.getBeamCoordinates(),
         .phasorAntennaCoefficientChannelRate = config.preBeamformerChannelizerRate,
+        .phasorNegateDelays = config.phasorNegateDelays,
 
         .beamformerIncoherentBeam = config.incoherentBeamEnabled,
 

--- a/apps/blade-cli/include/blade-cli/telescopes/ata/mode_bs.hh
+++ b/apps/blade-cli/include/blade-cli/telescopes/ata/mode_bs.hh
@@ -24,8 +24,6 @@ inline const Result ModeBS(const Config& config) {
     using Channelize = Pipelines::Generic::ModeH<IT, CF32>;
     using Beamform = Pipelines::ATA::ModeB<CF32, F32>;
     using Search = Pipelines::Generic::ModeS<Blade::Pipelines::Generic::HitsFormat::SETICORE_STAMP>;
-    using FilterbankWriter = Pipelines::Generic::Accumulator<Modules::Filterbank::Writer<F32>, Device::CPU, F32>;
-    std::unique_ptr<Runner<FilterbankWriter>> filterbankWriterRunner;
 
     ArrayDimensions stepTailIncrementDims = {.A=1, .F=1, .T=1, .P=1};
 
@@ -37,13 +35,13 @@ inline const Result ModeBS(const Config& config) {
         .inputGuppiFile = config.inputGuppiFile,
         .inputBfr5File = config.inputBfr5File,
         .stepNumberOfTimeSamples = config.preBeamformerChannelizerRate,
+        .requiredMultipleOfTimeSamplesSteps = config.stepNumberOfTimeSamples,
         .stepNumberOfFrequencyChannels = config.stepNumberOfFrequencyChannels,
-        .numberOfTimeSampleStepsBeforeFrequencyChannelStep = config.stepNumberOfTimeSamples,
+        .numberOfTimeSampleStepsBeforeFrequencyChannelStep = 0,
     };
 
     auto readerRunner = Runner<Reader>::New(1, readerConfig, false);
     const auto& reader = readerRunner->getWorker();
-
     
     const auto readerTotalOutputDims = reader.getTotalOutputDims();
     const auto readerStepsInDims = reader.getNumberOfStepsInDimensions();
@@ -133,6 +131,9 @@ inline const Result ModeBS(const Config& config) {
     // Instantiate search pipeline and runner.
 
     typename Search::Config searchConfig = {
+        // accumulate all time
+        .accumulateRate = readerTotalOutputDims.T / (config.preBeamformerChannelizerRate * config.stepNumberOfTimeSamples),
+
         .prebeamformerInputDimensions = beamformRunner->getWorker().getInputBuffer().dims(),
         .inputDimensions = beamformRunner->getWorker().getOutputBuffer().dims(),
 
@@ -163,42 +164,6 @@ inline const Result ModeBS(const Config& config) {
 
     auto searchRunner = Runner<Search>::New(config.numberOfWorkers, searchConfig, false);
 
-    // Instantiate writer pipeline and runner.
-    
-    typename FilterbankWriter::Config writerConfig = {
-        .moduleConfig = {
-            .filepath = config.outputFile,
-            
-            .machineId = 0,
-            .telescopeName = reader.getTelescopeName(),
-            .baryCentric = 1,
-            .pulsarCentric = 1,
-            .azimuthStart = reader.getAzimuthAngle(),
-            .zenithStart = reader.getZenithAngle(),
-            .firstChannelMiddleFrequencyHz = reader.getTopFrequency() - 0.5*reader.getChannelBandwidth()/config.preBeamformerChannelizerRate, // Top channel as the frequencies are descending
-            .bandwidthHz = reader.getBandwidth(),
-            .julianDateStart = reader.getJulianDateOfLastReadBlock(),
-            .spectrumTimespanS = config.preBeamformerChannelizerRate * config.integrationSize * reader.getChannelTimespan(),
-            .numberOfIfChannels = (I32) beamformRunner->getWorker().getOutputBuffer().dims().numberOfPolarizations(),
-            .sourceDataFilename = config.inputGuppiFile,
-            .beamNames = beamSourceNames,
-            .beamCoordinates = beamCoordinates,
-
-            .numberOfInputFrequencyChannelBatches = 1, // Accumulator pipeline set to reconstituteBatchedDimensions.
-        },
-        .inputDimensions = beamformRunner->getWorker().getOutputBuffer().dims(),
-        .inputIsATPFNotAFTP = true, // ModeB.detectorTransposedATPFOutput is enabled
-        .frequencyIsDescendingNotAscending = false,
-        .reconstituteBatchedDimensions = true,
-        .accumulateRate = readerTotalOutputDims.numberOfFrequencyChannels() / reader.getStepOutputDims().numberOfFrequencyChannels(),
-    };
-
-    const auto filterbankOutputEnabled = std::is_same<OT, F32>::value;
-    if (filterbankOutputEnabled) {
-        BL_WARN("The filterbank output will only show the first step in time-samples!");
-        filterbankWriterRunner = Runner<FilterbankWriter>::New(1, writerConfig, false);
-    }
-
     indicators::ProgressBar bar{
         option::BarWidth{100},
         option::Start{" ["},
@@ -218,16 +183,11 @@ inline const Result ModeBS(const Config& config) {
     U64 stepCount = 0;
     const U64 stepSearchIncrement = stepTailIncrementDims.size();
     BL_DEBUG("Tail increments require {} steps ({}).", stepSearchIncrement, stepTailIncrementDims);
-    stepTailIncrementDims.F *= writerConfig.accumulateRate;
-    const U64 stepFilterbankIncrement = stepTailIncrementDims.size();
-    BL_DEBUG("Filterbank steps {}.", stepFilterbankIncrement);
+
     U64 callbackStep = 0;
     U64 workerId = 0;
 
     const auto readerNumberOfSteps = readerStepsInDims.size(); // this accounts for numberOfTimeSampleStepsBeforeFrequencyChannelStep
-
-    BOOL writeComplete = !filterbankOutputEnabled;
-    BOOL searchComplete = false;
 
     while (Plan::Loop()) {
         readerRunner->enqueue([&](auto& worker){
@@ -294,27 +254,12 @@ inline const Result ModeBS(const Config& config) {
                 worker.getBlockJulianDate()
             );
 
-            if (filterbankOutputEnabled && worker.getBlockJulianDate()[0] == writerConfig.moduleConfig.julianDateStart) {
-                Plan::Accumulate(filterbankWriterRunner, beamformRunner,
-                                worker.getOutputBuffer());
-            }
-
             return callbackStep;
         });
 
         searchRunner->enqueue([&](auto& worker){
             // Try dequeue job from last runner. If unlucky, return.
             Plan::Dequeue(beamformRunner, &callbackStep, &workerId);
-
-            if (filterbankOutputEnabled) {
-                // write out the input to the searchRunner
-                filterbankWriterRunner->enqueue([&](auto& worker){
-                    // If accumulation complete, write data to disk.
-                    Plan::Compute(worker);
-
-                    return callbackStep;
-                });
-            }
 
             // If accumulation complete, dedoppler-search data.
             Plan::Compute(worker);
@@ -325,24 +270,8 @@ inline const Result ModeBS(const Config& config) {
         // Try to dequeue job from the final runner.
         if (searchRunner->dequeue(&callbackStep, &workerId)) {
             if (callbackStep + stepSearchIncrement > readerNumberOfSteps) {
-                searchComplete = true;
+                break;
             }
-        }
-
-        if (filterbankOutputEnabled) {
-            // Try to dequeue job from the writer runner.
-            if (filterbankWriterRunner->dequeue(&callbackStep, &workerId)) {
-                BL_INFO("{}: Filterbank written, containing the input to the dedoppler search.", callbackStep);
-
-                if (callbackStep + stepFilterbankIncrement > readerNumberOfSteps) {
-                    BL_INFO("Filterbank completed.");
-                    writeComplete = true;
-                }
-            }
-        }
-
-        if (writeComplete && searchComplete) {
-            break;
         }
     }
 
@@ -352,7 +281,6 @@ inline const Result ModeBS(const Config& config) {
     channelizeRunner.reset();
     beamformRunner.reset();
     searchRunner.reset();
-    filterbankWriterRunner.reset();
 
     return Result::SUCCESS;
 }

--- a/apps/blade-cli/include/blade-cli/telescopes/ata/mode_bs.hh
+++ b/apps/blade-cli/include/blade-cli/telescopes/ata/mode_bs.hh
@@ -98,6 +98,7 @@ inline const Result ModeBS(const Config& config) {
         ),
         .phasorBeamCoordinates = reader.getBeamCoordinates(),
         .phasorAntennaCoefficientChannelRate = config.preBeamformerChannelizerRate,
+        .phasorNegateDelays = config.phasorNegateDelays,
 
         .beamformerIncoherentBeam = true,
 

--- a/apps/blade-cli/include/blade-cli/telescopes/ata/mode_bs.hh
+++ b/apps/blade-cli/include/blade-cli/telescopes/ata/mode_bs.hh
@@ -38,6 +38,7 @@ inline const Result ModeBS(const Config& config) {
         .requiredMultipleOfTimeSamplesSteps = config.stepNumberOfTimeSamples,
         .stepNumberOfFrequencyChannels = config.stepNumberOfFrequencyChannels,
         .numberOfTimeSampleStepsBeforeFrequencyChannelStep = 0,
+        .numberOfGuppiFilesLimit = config.inputGuppiFileLimit,
     };
 
     auto readerRunner = Runner<Reader>::New(1, readerConfig, false);

--- a/apps/blade-cli/src/telescopes/ata.cc
+++ b/apps/blade-cli/src/telescopes/ata.cc
@@ -161,7 +161,7 @@ const Result CollectUserInput(int argc, char **argv, Config& config) {
     config.produceDebugHits = false;
     app
         .add_flag("--produce-debug-hits", config.produceDebugHits,
-                "SETI search artificial hits are made covering all ingest data. Stitching the stamps together should yield the full upchannelised data. Disables hits grouping and stamp frequency margins.");
+                "SETI search artificial hits are made covering all ingest data. The filterbank field of the hits collectively have the beamformed data. The data field of the stamps collectively have all upchannelised data. Disables hits grouping and stamp frequency margins.");
 
     // Read stamps frequency margin.
     app

--- a/apps/blade-cli/src/telescopes/ata.cc
+++ b/apps/blade-cli/src/telescopes/ata.cc
@@ -174,6 +174,12 @@ const Result CollectUserInput(int argc, char **argv, Config& config) {
     app
         .add_flag("--negate-phasor-delays", config.phasorNegateDelays,
                 "Negate the delays from which the beamforming-phasors are calculated.");
+    
+    // Read guppi file limit.
+    app
+        .add_option("--input-guppi-raw-limit", config.inputGuppiFileLimit,
+                "Limit the number of RAW files to process (0 for no limit).")
+            ->default_val(0);
 
     try {
         app.parse(argc, argv);

--- a/apps/blade-cli/src/telescopes/ata.cc
+++ b/apps/blade-cli/src/telescopes/ata.cc
@@ -137,7 +137,7 @@ const Result CollectUserInput(int argc, char **argv, Config& config) {
     config.driftRateZeroExcluded = false;
     app
         .add_flag("-Z,--search-drift-rate-exclude-zero", config.driftRateZeroExcluded,
-                "SETI search exclude hits with drift rate of zero");
+                "SETI search exclude hits with drift rate of zero (short-hand for setting --search-drift-rate-minimum to the Dedoppler drift rate resolution)");
     
     // Read incoherent beam enable.
     config.incoherentBeamEnabled = false;

--- a/apps/blade-cli/src/telescopes/ata.cc
+++ b/apps/blade-cli/src/telescopes/ata.cc
@@ -145,11 +145,29 @@ const Result CollectUserInput(int argc, char **argv, Config& config) {
         .add_flag("-I,--incoherent-beam-enable", config.incoherentBeamEnabled,
                 "Beamform the incoherent beam");
     
-    // Read progress bar enable.
+    // Read progress bar disable.
     config.progressBarDisabled = false;
     app
         .add_flag("-P,--no-progress-bar", config.progressBarDisabled,
                 "Switch off the progress bar.");
+    
+    // Read seticore hits grouping margin
+    app
+        .add_option("--hits-grouping-margin", config.hitsGroupingMargin,
+                "SETI search grouping margin specified in channels.")
+            ->default_val(30);
+    
+    // Read debug hits enable.
+    config.produceDebugHits = false;
+    app
+        .add_flag("--produce-debug-hits", config.produceDebugHits,
+                "SETI search artificial hits are made covering all ingest data. Stitching the stamps together should yield the full upchannelised data. Disables hits grouping and stamp frequency margins.");
+
+    // Read stamps frequency margin.
+    app
+        .add_option("--stamp-frequency-margin", config.stampFrequencyMarginHz,
+                "SETI search stamps frequency marginal padding.")
+            ->default_val(500.0);
 
     try {
         app.parse(argc, argv);

--- a/apps/blade-cli/src/telescopes/ata.cc
+++ b/apps/blade-cli/src/telescopes/ata.cc
@@ -168,6 +168,12 @@ const Result CollectUserInput(int argc, char **argv, Config& config) {
         .add_option("--stamp-frequency-margin", config.stampFrequencyMarginHz,
                 "SETI search stamps frequency marginal padding.")
             ->default_val(500.0);
+    
+    // Read phasor delays negation.
+    config.phasorNegateDelays = false;
+    app
+        .add_flag("--negate-phasor-delays", config.phasorNegateDelays,
+                "Negate the delays from which the beamforming-phasors are calculated.");
 
     try {
         app.parse(argc, argv);

--- a/include/blade/memory/devices/cpu/copy.hh
+++ b/include/blade/memory/devices/cpu/copy.hh
@@ -39,6 +39,67 @@ static const Result Copy(Vector<Device::CPU, Type, Dims>& dst,
     return Result::SUCCESS;
 }
 
+template<typename Type, typename Dims>
+static const Result Copy2D(Vector<Device::CPU, Type, Dims>& dst,
+                           const U64& dstPitch,
+                           const U64& dstOffset, 
+                           const Vector<Device::CPU, Type, Dims>& src,
+                           const U64& srcPitch,
+                           const U64& srcOffset,
+                           const U64& width_bytes,
+                           const U64& height) {
+    if (width_bytes > dstPitch) {
+        BL_FATAL("2D copy 'width' is larger than destination's pitch ({}, {}).",
+                width_bytes, dstPitch);
+        return Result::ASSERTION_ERROR;
+    }
+
+    if (dst.size_bytes() < (dstPitch * height)) {
+        BL_FATAL("Destination's size is exceeded by {} rows of {} ({} vs {}).",
+                height, dstPitch, dst.size_bytes(), dstPitch * height);
+        return Result::ASSERTION_ERROR;
+    }
+
+    if (width_bytes > srcPitch) {
+        BL_FATAL("2D copy 'width' is larger than source's pitch ({}, {}).",
+                width_bytes, srcPitch);
+        return Result::ASSERTION_ERROR;
+    }
+
+    if (src.size_bytes() < (srcPitch * height)) {
+        BL_FATAL("Source's size is exceeded by {} rows of {} ({} vs {}).",
+                height, srcPitch, src.size_bytes(), srcPitch * height);
+        return Result::ASSERTION_ERROR;
+    }
+
+    if (width_bytes % sizeof(Type) != 0) {
+        BL_FATAL("2D copy 'width' is not a multiple of element size ({}, {}).",
+                width_bytes, sizeof(Type));
+        return Result::ASSERTION_ERROR;
+    }
+
+    if (srcOffset % sizeof(Type) != 0) {
+        BL_FATAL("2D copy source offset (bytes) is not a multiple of element size ({}, {}).",
+                srcOffset, sizeof(Type));
+        return Result::ASSERTION_ERROR;
+    }
+
+    auto dst_data = dst.data() + dstOffset;
+    auto src_data = src.data() + srcOffset;
+
+    for (U64 i = 0; i < height; i++) {
+        memcpy(
+            dst_data,
+            src_data,
+            width_bytes
+        );
+        dst_data += dstPitch;
+        src_data += srcPitch;
+    }
+
+    return Result::SUCCESS;
+}
+
 }  // namespace Blade::Memory
 
 #endif

--- a/include/blade/modules/guppi/reader.hh
+++ b/include/blade/modules/guppi/reader.hh
@@ -27,6 +27,7 @@ class BLADE_API Reader : public Module {
 
         U64 numberOfTimeSampleStepsBeforeFrequencyChannelStep = 1;
         U64 blockSize = 512;
+        U64 numberOfFilesLimit = 0; // zero for no limit
     };
 
     constexpr const Config& getConfig() const {

--- a/include/blade/modules/guppi/reader.hh
+++ b/include/blade/modules/guppi/reader.hh
@@ -138,7 +138,7 @@ class BLADE_API Reader : public Module {
     U64 lastread_block_index = 0;
     U64 lastread_time_index = 0;
 
-    ArrayDimensions currentStepDimensionIndices = {.A = 0, .F = 0, .T = 0, .P = 0};
+    U64 current_time_sample_step = 0;
     U64 checkpoint_block_index = 0;
     U64 checkpoint_time_index = 0;
 

--- a/include/blade/modules/phasor/generic.hh
+++ b/include/blade/modules/phasor/generic.hh
@@ -27,6 +27,7 @@ class BLADE_API Generic : public Module {
         std::vector<RA_DEC> beamCoordinates;
 
         U64 antennaCoefficientChannelRate = 1;
+        U64 negateDelays = false;
 
         U64 blockSize = 512;
     };

--- a/include/blade/modules/seticore/dedoppler.hh
+++ b/include/blade/modules/seticore/dedoppler.hh
@@ -38,6 +38,8 @@ class BLADE_API Dedoppler : public Module {
         U64 totalNumberOfTimeSamples;
         U64 totalNumberOfFrequencyChannels;
 
+        BOOL produceDebugHits = false;
+
         U64 blockSize = 512;
     };
 

--- a/include/blade/modules/seticore/dedoppler.hh
+++ b/include/blade/modules/seticore/dedoppler.hh
@@ -82,6 +82,7 @@ class BLADE_API Dedoppler : public Module {
     // Variables
 
     ArrayTensor<Device::CUDA, F32> searchBuffer;
+    ArrayTensor<Device::CUDA, F32> incohBuffer;
 
     const Config config;
     const Input input;

--- a/include/blade/modules/seticore/dedoppler.hh
+++ b/include/blade/modules/seticore/dedoppler.hh
@@ -48,7 +48,7 @@ class BLADE_API Dedoppler : public Module {
     // Input
 
     struct Input {
-        const ArrayTensor<Device::CUDA, F32>& buf;
+        const ArrayTensor<Device::CPU, F32>& buf;
         const Vector<Device::CPU, U64>& coarseFrequencyChannelOffset;
         const Vector<Device::CPU, F64>& julianDate;
     };
@@ -79,7 +79,7 @@ class BLADE_API Dedoppler : public Module {
     private:
     // Variables
 
-    ArrayTensor<Device::CPU, F32> buf;
+    ArrayTensor<Device::CUDA, F32> searchBuffer;
 
     const Config config;
     const Input input;

--- a/include/blade/modules/seticore/hits_raw_writer.hh
+++ b/include/blade/modules/seticore/hits_raw_writer.hh
@@ -35,7 +35,6 @@ class BLADE_API HitsRawWriter : public Module {
         F64 channelTimespanS;
         F64 stampFrequencyMarginHz = 500.0;
         I64 hitsGroupingMargin = 30;
-        BOOL excludeDriftRateZero = false;
 
         U64 blockSize = 512;
     };

--- a/include/blade/modules/seticore/hits_raw_writer.hh
+++ b/include/blade/modules/seticore/hits_raw_writer.hh
@@ -33,7 +33,8 @@ class BLADE_API HitsRawWriter : public Module {
         U64 coarseChannelRatio;
         F64 channelBandwidthHz;
         F64 channelTimespanS;
-        U64 hitsGroupingMargin = 30;
+        F64 stampFrequencyMarginHz = 500.0;
+        I64 hitsGroupingMargin = 30;
         BOOL excludeDriftRateZero = false;
 
         U64 blockSize = 512;

--- a/include/blade/modules/seticore/hits_stamp_writer.hh
+++ b/include/blade/modules/seticore/hits_stamp_writer.hh
@@ -41,7 +41,6 @@ class BLADE_API HitsStampWriter : public Module {
         F64 channelTimespanS;
         F64 stampFrequencyMarginHz = 500.0;
         I64 hitsGroupingMargin = 30;
-        BOOL excludeDriftRateZero = false;
 
         U64 blockSize = 512;
     };

--- a/include/blade/modules/seticore/hits_stamp_writer.hh
+++ b/include/blade/modules/seticore/hits_stamp_writer.hh
@@ -39,7 +39,8 @@ class BLADE_API HitsStampWriter : public Module {
         U64 coarseChannelRatio;
         F64 channelBandwidthHz;
         F64 channelTimespanS;
-        U64 hitsGroupingMargin = 30;
+        F64 stampFrequencyMarginHz = 500.0;
+        I64 hitsGroupingMargin = 30;
         BOOL excludeDriftRateZero = false;
 
         U64 blockSize = 512;

--- a/include/blade/pipelines/ata/mode_b.hh
+++ b/include/blade/pipelines/ata/mode_b.hh
@@ -38,6 +38,7 @@ class BLADE_API ModeB : public Pipeline {
         std::vector<CF64> phasorAntennaCoefficients; 
         std::vector<RA_DEC> phasorBeamCoordinates;
         U64 phasorAntennaCoefficientChannelRate;
+        BOOL phasorNegateDelays;
 
         BOOL beamformerIncoherentBeam = false;
 

--- a/include/blade/pipelines/generic/file_reader.hh
+++ b/include/blade/pipelines/generic/file_reader.hh
@@ -22,6 +22,7 @@ class BLADE_API FileReader : public Pipeline {
         U64 requiredMultipleOfTimeSamplesSteps = 1;
         U64 stepNumberOfFrequencyChannels;
         U64 numberOfTimeSampleStepsBeforeFrequencyChannelStep = 1;
+        U64 numberOfGuppiFilesLimit = 0; // zero for no limit
     };
 
     explicit FileReader(const Config& config);

--- a/include/blade/pipelines/generic/file_reader.hh
+++ b/include/blade/pipelines/generic/file_reader.hh
@@ -19,6 +19,7 @@ class BLADE_API FileReader : public Pipeline {
         std::string inputBfr5File;
 
         U64 stepNumberOfTimeSamples;
+        U64 requiredMultipleOfTimeSamplesSteps = 1;
         U64 stepNumberOfFrequencyChannels;
         U64 numberOfTimeSampleStepsBeforeFrequencyChannelStep = 1;
     };

--- a/include/blade/pipelines/generic/mode_s.hh
+++ b/include/blade/pipelines/generic/mode_s.hh
@@ -35,6 +35,7 @@ class BLADE_API ModeS : public Pipeline {
     // Configuration 
 
     struct Config {
+        U64 accumulateRate = 1;
         ArrayDimensions prebeamformerInputDimensions;
         ArrayDimensions inputDimensions;
 
@@ -101,7 +102,7 @@ class BLADE_API ModeS : public Pipeline {
  private:
     const Config config;
 
-    ArrayTensor<Device::CUDA, F32> input;
+    ArrayTensor<Device::CPU, F32> input;
     ArrayTensor<Device::CPU, CF32> prebeamformerData;
     Vector<Device::CPU, U64> coarseFrequencyChannelOffset;
     Vector<Device::CPU, F64> frequencyOfFirstChannelHz;

--- a/include/blade/pipelines/generic/mode_s.hh
+++ b/include/blade/pipelines/generic/mode_s.hh
@@ -58,11 +58,15 @@ class BLADE_API ModeS : public Pipeline {
         F64 searchMinimumDriftRate = 0.0;
         F64 searchMaximumDriftRate;
         F64 searchSnrThreshold;
+        F64 searchStampFrequencyMarginHz;
+        I64 searchHitsGroupingMargin;
         BOOL searchIncoherentBeam = true;
 
         F64 searchChannelBandwidthHz;
         F64 searchChannelTimespanS;
         std::string searchOutputFilepathStem;
+
+        BOOL produceDebugHits = false;
 
         U64 dedopplerBlockSize = 512;
     };

--- a/src/modules/guppi/reader.cc
+++ b/src/modules/guppi/reader.cc
@@ -108,6 +108,7 @@ Reader<OT>::Reader(const Config& config, const Input& input)
         BL_CHECK_THROW(Result::ASSERTION_ERROR);
     }
 
+    this->gr_iterate.n_file = config.numberOfFilesLimit;
     // Open GUPPI file and configure step size.
     const auto res =
         guppiraw_iterate_open_with_user_metadata(&gr_iterate,
@@ -155,7 +156,7 @@ Reader<OT>::Reader(const Config& config, const Input& input)
         BL_INFO("Stepping Frequency Channels after every {} steps in Time Samples", config.numberOfTimeSampleStepsBeforeFrequencyChannelStep);
         gr_iterate.iterate_time_first_not_channel_first = true;
     }
-    BL_INFO("Total Dimensions [A, F, T, P]: {} -> {}", "N/A", totalDims);
+    BL_INFO("Total Dimensions [A, F, T, P]: {} -> {} (across {} {})", "N/A", totalDims, this->gr_iterate.n_file, this->gr_iterate.n_file > 1 ? "files" : "file");
     BL_INFO("Steps in Dimensions [A, F, T, P]: {}", getNumberOfStepsInDimensions());
     if(config.requiredMultipleOfTimeSamplesSteps > 1) {
         BL_INFO("Rounded down to multiple of {} time steps", config.requiredMultipleOfTimeSamplesSteps);

--- a/src/modules/phasor/ata.cc
+++ b/src/modules/phasor/ata.cc
@@ -190,7 +190,7 @@ const Result ATA<OT>::preprocess(const cudaStream_t& stream,
                                        this->antennaCoefficients.dims().numberOfFrequencyChannels() *
                                        this->config.numberOfPolarizations);
 
-            const F64 delay = this->output.delays[(b * this->config.numberOfAntennas) + a];
+            const F64 delay = this->output.delays[(b * this->config.numberOfAntennas) + a] * (this->config.negateDelays ? -1 : 1);
             const CF64 fringeRateExp(0, -2 * BL_PHYSICAL_CONSTANT_PI * delay * (this->config.bottomFrequencyHz + this->input.blockFrequencyChannelOffset[0] * this->config.channelBandwidthHz)); 
 
 

--- a/src/modules/phasor/generic.cc
+++ b/src/modules/phasor/generic.cc
@@ -60,6 +60,7 @@ Generic<OT>::Generic(const Config& config, const Input& input)
 
     // Print generic configuration values.
     BL_INFO("Type: {} -> {}", "N/A", TypeInfo<OT>::name);
+    BL_INFO("Delays Negated: {}", config.negateDelays);
     BL_INFO("Bottom Frequency (Hz): {}", config.bottomFrequencyHz);
     BL_INFO("Channel Bandwidth (Hz): {}", config.channelBandwidthHz);
     BL_INFO("Reference Antenna Index: {}", config.referenceAntennaIndex);

--- a/src/modules/seticore/dedoppler.cc
+++ b/src/modules/seticore/dedoppler.cc
@@ -203,11 +203,11 @@ const Result Dedoppler::process(const cudaStream_t& stream) {
             &this->output.hits
         );
 
-        if (this->config.lastBeamIsIncoherent) {
         std::vector<DedopplerHit> beam_hits(
             this->output.hits.begin() + hits_after_last_beam,
             this->output.hits.end()
         );
+        if (this->config.lastBeamIsIncoherent) {
             dedopplerer.addIncoherentPower(
                 incohbeamFilterbankBuffer,
                 beam_hits

--- a/src/modules/seticore/hits_raw_writer.cc
+++ b/src/modules/seticore/hits_raw_writer.cc
@@ -27,11 +27,15 @@ HitsRawWriter<IT>::HitsRawWriter(const Config& config, const Input& input)
     BL_INFO("Dimensions [A, F, T, P]: {} -> {}", getInputBuffer().dims(), "N/A");
     BL_INFO("Output File Path: {}", config.filepathPrefix);
     BL_INFO("Direct I/O: {}", config.directio ? "YES" : "NO");
-    BL_INFO("Excluding Zero Drift Rate Hits: {}", config.excludeDriftRateZero ? "YES" : "NO");
 }
 
 template<typename IT>
 const Result HitsRawWriter<IT>::process(const cudaStream_t& stream) {
+    if (input.hits.size() == 0) {
+        BL_DEBUG("No hits.");
+        return Result::SUCCESS;
+    }
+
     const auto inputDims = getInputBuffer().dims();
     const auto frequencyChannelStride = getInputBuffer().size() / (inputDims.numberOfAspects()*inputDims.numberOfFrequencyChannels());
 
@@ -44,33 +48,72 @@ const Result HitsRawWriter<IT>::process(const cudaStream_t& stream) {
     }
 
     vector<DedopplerHitGroup> groups = makeHitGroups(input.hits, this->config.hitsGroupingMargin);
+    // The grouping mechanism ensures all hits are in a single group.
+    // The groups bounds are transitive, expanding with each new-comer
+    // Because of this, some groups could have overlapping channel-spans.
+    // The real objective is just to ensure that all frequency data that
+    // resulted in a hit is stamped out. So leave them be, but don't stamp
+    // frequency ranges twice...
+    
+    vector<U64> stamps_first_channel;
+    vector<U64> stamps_last_channel;
+    stamps_first_channel.reserve(groups.size());
+    stamps_last_channel.reserve(groups.size());
     BL_DEBUG("{} group(s) of the search's {} hit(s), stamps are padded by {} frequency-channels.", groups.size(), input.hits.size(), hitStampFrequencyMargin);
     for (const DedopplerHitGroup& group : groups) {
-        const DedopplerHit& top_hit = group.topHit();
-    // for (const DedopplerHit& top_hit : input.hits) {
-
-        if (this->config.excludeDriftRateZero && top_hit.drift_steps == 0) {
-            continue;
+        // Consider the group
+        //  a stamp covers the extremes of all the hits
+        //  + the hitStampFrequencyMargin
+        int lowIndex = inputDims.numberOfFrequencyChannels();
+        int highIndex = 0;
+        for (const DedopplerHit& hit : group.hits) {
+            if (hit.lowIndex() < lowIndex) {
+                lowIndex = hit.lowIndex();
+            }
+            if (hit.highIndex() > highIndex) {
+                highIndex = hit.highIndex();
+            }
         }
 
-        // Extract the stamp
-        const int lowIndex = top_hit.lowIndex() - hitStampFrequencyMargin;
-        U64 first_channel = lowIndex < 0 ? 0 : (U64) lowIndex;
-        U64 highIndex = top_hit.highIndex() + hitStampFrequencyMargin;
-        U64 last_channel = highIndex > inputDims.numberOfFrequencyChannels() ? inputDims.numberOfFrequencyChannels() : highIndex;
-        
-        BL_DEBUG("Top hit: {}", top_hit.toString());
+        lowIndex -= hitStampFrequencyMargin;
+        highIndex += hitStampFrequencyMargin;
+        const U64 first_channel = lowIndex < 0 ? 0 : (U64) lowIndex;
+        const U64 last_channel = highIndex > inputDims.numberOfFrequencyChannels() ? inputDims.numberOfFrequencyChannels() : (U64) highIndex;
+
         BL_DEBUG(
-            "Extracting fine channels [{}, {}) from coarse channel {}",
+            "Group channel range spans [{}, {}].",
             first_channel,
-            last_channel,
-            top_hit.coarse_channel
+            last_channel
         );
         if (first_channel > last_channel) {
-            const U64 tmp_channel = last_channel;
-            first_channel = tmp_channel;
-            last_channel = first_channel;
+            BL_FATAL("Channels are wrong way around");
+            BL_CHECK_THROW(Result::ERROR);
         }
+        
+        // double check that this channel range has not already been stamped
+        bool stamp_is_novel = true;
+        for (size_t index = 0; stamp_is_novel && index < stamps_first_channel.size(); index++) {
+            stamp_is_novel &= !(stamps_first_channel.at(index) <= first_channel
+                && stamps_last_channel.at(index) >= last_channel);
+            
+            if (!stamp_is_novel) {
+                BL_DEBUG(
+                    "Group channel range covered by previous stamp #{} spanning [{}, {}]",
+                    index,
+                    stamps_first_channel.at(index),
+                    stamps_last_channel.at(index)
+                );
+            }
+        }
+        if (!stamp_is_novel) {
+            continue;
+        }
+        
+        // Extract the stamp
+        const DedopplerHit& top_hit = group.topHit();
+        BL_DEBUG("Stamp #{} of group with top hit: {}", stamps_first_channel.size(), top_hit.toString());
+        stamps_first_channel.emplace_back(first_channel);
+        stamps_last_channel.emplace_back(last_channel);
 
         // Open output file.
         auto filepath = fmt::format("{}.seticore.{:04}.raw", this->config.filepathPrefix, this->fileId % 10000);

--- a/src/modules/seticore/hits_raw_writer.cc
+++ b/src/modules/seticore/hits_raw_writer.cc
@@ -57,7 +57,7 @@ const Result HitsRawWriter<IT>::process(const cudaStream_t& stream) {
         const int lowIndex = top_hit.lowIndex() - hitStampFrequencyMargin;
         U64 first_channel = lowIndex < 0 ? 0 : (U64) lowIndex;
         U64 highIndex = top_hit.highIndex() + hitStampFrequencyMargin;
-        U64 last_channel = highIndex >= inputDims.numberOfFrequencyChannels() ? inputDims.numberOfFrequencyChannels()-1 : highIndex;
+        U64 last_channel = highIndex > inputDims.numberOfFrequencyChannels() ? inputDims.numberOfFrequencyChannels() : highIndex;
         
         BL_DEBUG("Top hit: {}", top_hit.toString());
         BL_DEBUG(

--- a/src/modules/seticore/hits_stamp_writer.cc
+++ b/src/modules/seticore/hits_stamp_writer.cc
@@ -19,7 +19,6 @@ HitsStampWriter<IT>::HitsStampWriter(const Config& config, const Input& input)
     BL_INFO("Type: {} -> {}", TypeInfo<IT>::name, "N/A");
     BL_INFO("Dimensions [A, F, T, P]: {} -> {}", getInputBuffer().dims(), "N/A");
     BL_INFO("Output File Path: {}", config.filepathPrefix);
-    BL_INFO("Excluding Zero Drift Rate Hits: {}", config.excludeDriftRateZero ? "YES" : "NO");
 }
 
 template<typename IT>
@@ -33,6 +32,7 @@ HitsStampWriter<IT>::~HitsStampWriter() {
 template<typename IT>
 const Result HitsStampWriter<IT>::process(const cudaStream_t& stream) {
     if (input.hits.size() == 0) {
+        BL_DEBUG("No hits.");
         return Result::SUCCESS;
     }
 
@@ -47,28 +47,73 @@ const Result HitsStampWriter<IT>::process(const cudaStream_t& stream) {
     }
 
     vector<DedopplerHitGroup> groups = makeHitGroups(input.hits, this->config.hitsGroupingMargin);
+    // The grouping mechanism ensures all hits are in a single group.
+    // The groups bounds are transitive, expanding with each new-comer
+    // Because of this, some groups could have overlapping channel-spans.
+    // The real objective is just to ensure that all frequency data that
+    // resulted in a hit is stamped out. So leave them be, but don't stamp
+    // frequency ranges twice...
+
+    vector<U64> stamps_first_channel;
+    vector<U64> stamps_last_channel;
+    stamps_first_channel.reserve(groups.size());
+    stamps_last_channel.reserve(groups.size());
     BL_DEBUG("{} group(s) of the search's {} hit(s), stamps are padded by {} frequency-channels.", groups.size(), input.hits.size(), hitStampFrequencyMargin);
     for (const DedopplerHitGroup& group : groups) {
-        const DedopplerHit& top_hit = group.topHit();
-    // for (const DedopplerHit& top_hit : input.hits) {
-
-        if (this->config.excludeDriftRateZero && top_hit.drift_steps == 0) {
-            continue;
+        // Consider the group
+        //  a stamp covers the extremes of all the hits
+        //  + the hitStampFrequencyMargin
+        int lowIndex = inputDims.numberOfFrequencyChannels();
+        int highIndex = 0;
+        for (const DedopplerHit& hit : group.hits) {
+            if (hit.lowIndex() < lowIndex) {
+                lowIndex = hit.lowIndex();
+            }
+            if (hit.highIndex() > highIndex) {
+                highIndex = hit.highIndex();
+            }
         }
 
-        // Extract the stamp
-        const int lowIndex = top_hit.lowIndex() - hitStampFrequencyMargin;
-        U64 first_channel = lowIndex < 0 ? 0 : (U64) lowIndex;
-        U64 highIndex = top_hit.highIndex() + hitStampFrequencyMargin;
-        U64 last_channel = highIndex > inputDims.numberOfFrequencyChannels() ? inputDims.numberOfFrequencyChannels() : highIndex;
-        
-        BL_DEBUG("Top hit: {}", top_hit.toString());
+        lowIndex -= hitStampFrequencyMargin;
+        highIndex += hitStampFrequencyMargin;
+        const U64 first_channel = lowIndex < 0 ? 0 : (U64) lowIndex;
+        const U64 last_channel = highIndex > inputDims.numberOfFrequencyChannels() ? inputDims.numberOfFrequencyChannels() : (U64) highIndex;
+
         BL_DEBUG(
-            "Extracting fine channels [{}, {}) from coarse channel {}",
+            "Group channel range spans [{}, {}].",
             first_channel,
-            last_channel,
-            top_hit.coarse_channel
+            last_channel
         );
+        if (first_channel > last_channel) {
+            BL_FATAL("Channels are wrong way around");
+            BL_CHECK_THROW(Result::ERROR);
+        }
+        
+        // double check that this channel range has not already been stamped
+        bool stamp_is_novel = true;
+        for (size_t index = 0; stamp_is_novel && index < stamps_first_channel.size(); index++) {
+            stamp_is_novel &= !(stamps_first_channel.at(index) <= first_channel
+                && stamps_last_channel.at(index) >= last_channel);
+            
+            if (!stamp_is_novel) {
+                BL_DEBUG(
+                    "Group channel range covered by previous stamp #{} spanning [{}, {}]",
+                    index,
+                    stamps_first_channel.at(index),
+                    stamps_last_channel.at(index)
+                );
+            }
+        }
+        if (!stamp_is_novel) {
+            continue;
+        }
+        
+        // Extract the stamp
+        const DedopplerHit& top_hit = group.topHit();
+        BL_DEBUG("Stamp #{} of group with top hit: {}", stamps_first_channel.size(), top_hit.toString());
+        stamps_first_channel.emplace_back(first_channel);
+        stamps_last_channel.emplace_back(last_channel);
+
         const ArrayDimensions regionOfInterestDims = {
             .A = inputDims.numberOfAspects(),
             .F = (U64) (last_channel - first_channel),

--- a/src/modules/seticore/hits_stamp_writer.cc
+++ b/src/modules/seticore/hits_stamp_writer.cc
@@ -38,10 +38,16 @@ const Result HitsStampWriter<IT>::process(const cudaStream_t& stream) {
 
     const auto inputDims = getInputBuffer().dims();
 
-    const int hitStampFrequencyMargin = this->config.channelBandwidthHz < 500.0 ? 500.0 / this->config.channelBandwidthHz : 1;
+    int hitStampFrequencyMargin = 1;
+    if (this->config.stampFrequencyMarginHz <= 0.0) {
+        hitStampFrequencyMargin = 0;
+    }
+    else if (abs(this->config.channelBandwidthHz) < this->config.stampFrequencyMarginHz) {
+        hitStampFrequencyMargin = this->config.stampFrequencyMarginHz / abs(this->config.channelBandwidthHz);
+    }
 
     vector<DedopplerHitGroup> groups = makeHitGroups(input.hits, this->config.hitsGroupingMargin);
-    BL_DEBUG("{} group(s) of the search's {} hit(s)", groups.size(), input.hits.size());
+    BL_DEBUG("{} group(s) of the search's {} hit(s), stamps are padded by {} frequency-channels.", groups.size(), input.hits.size(), hitStampFrequencyMargin);
     for (const DedopplerHitGroup& group : groups) {
         const DedopplerHit& top_hit = group.topHit();
     // for (const DedopplerHit& top_hit : input.hits) {
@@ -63,11 +69,6 @@ const Result HitsStampWriter<IT>::process(const cudaStream_t& stream) {
             last_channel,
             top_hit.coarse_channel
         );
-        if (first_channel > last_channel) {
-            const U64 tmp_channel = last_channel;
-            last_channel = first_channel;
-            first_channel = tmp_channel;
-        }
         const ArrayDimensions regionOfInterestDims = {
             .A = inputDims.numberOfAspects(),
             .F = (U64) (last_channel - first_channel),

--- a/src/modules/seticore/hits_stamp_writer.cc
+++ b/src/modules/seticore/hits_stamp_writer.cc
@@ -60,7 +60,7 @@ const Result HitsStampWriter<IT>::process(const cudaStream_t& stream) {
         const int lowIndex = top_hit.lowIndex() - hitStampFrequencyMargin;
         U64 first_channel = lowIndex < 0 ? 0 : (U64) lowIndex;
         U64 highIndex = top_hit.highIndex() + hitStampFrequencyMargin;
-        U64 last_channel = highIndex >= inputDims.numberOfFrequencyChannels() ? inputDims.numberOfFrequencyChannels()-1 : highIndex;
+        U64 last_channel = highIndex > inputDims.numberOfFrequencyChannels() ? inputDims.numberOfFrequencyChannels() : highIndex;
         
         BL_DEBUG("Top hit: {}", top_hit.toString());
         BL_DEBUG(

--- a/src/pipelines/ata/mode_b.cc
+++ b/src/pipelines/ata/mode_b.cc
@@ -68,6 +68,7 @@ ModeB<IT, OT>::ModeB(const Config& config)
         .beamCoordinates = config.phasorBeamCoordinates,
 
         .antennaCoefficientChannelRate = this->config.phasorAntennaCoefficientChannelRate,
+        .negateDelays = this->config.phasorNegateDelays,
 
         .blockSize = config.phasorBlockSize,
     }, {

--- a/src/pipelines/generic/file_reader.cc
+++ b/src/pipelines/generic/file_reader.cc
@@ -12,6 +12,7 @@ FileReader<OT>::FileReader(const Config& config) : config(config) {
     this->connect(guppi, {
         .filepath = config.inputGuppiFile,
         .stepNumberOfTimeSamples = config.stepNumberOfTimeSamples, 
+        .requiredMultipleOfTimeSamplesSteps = config.requiredMultipleOfTimeSamplesSteps,
         .stepNumberOfFrequencyChannels = config.stepNumberOfFrequencyChannels,
         .numberOfTimeSampleStepsBeforeFrequencyChannelStep = config.numberOfTimeSampleStepsBeforeFrequencyChannelStep,
     }, {});

--- a/src/pipelines/generic/file_reader.cc
+++ b/src/pipelines/generic/file_reader.cc
@@ -15,6 +15,7 @@ FileReader<OT>::FileReader(const Config& config) : config(config) {
         .requiredMultipleOfTimeSamplesSteps = config.requiredMultipleOfTimeSamplesSteps,
         .stepNumberOfFrequencyChannels = config.stepNumberOfFrequencyChannels,
         .numberOfTimeSampleStepsBeforeFrequencyChannelStep = config.numberOfTimeSampleStepsBeforeFrequencyChannelStep,
+        .numberOfFilesLimit = config.numberOfGuppiFilesLimit,
     }, {});
 
     BL_DEBUG("Instantiating BFR5 file reader.");

--- a/src/pipelines/generic/mode_s.cc
+++ b/src/pipelines/generic/mode_s.cc
@@ -267,7 +267,8 @@ const Result ModeS<HT>::accumulate(const ArrayTensor<Device::CUDA, F32>& data,
                 0,
 
                 inputWidth,
-                inputHeight
+                inputHeight,
+                stream
             )
         );
 

--- a/src/pipelines/generic/mode_s.cc
+++ b/src/pipelines/generic/mode_s.cc
@@ -149,7 +149,8 @@ const Result ModeS<HT>::accumulate(const ArrayTensor<Device::CUDA, F32>& data,
         
         BL_CHECK(Memory::Copy(
             this->input,
-            data
+            data,
+            stream
         ));
     }
     else {
@@ -198,7 +199,7 @@ const Result ModeS<HT>::accumulate(const ArrayTensor<Device::CUDA, F32>& data,
     }
 
     BL_DEBUG(
-        "accumulate from CPU: {}/{}\nschan: {}\nfch1: {}\njd: {}",
+        "accumulate from RAM: {}/{}\nschan: {}\nfch1: {}\njd: {}",
         this->getCurrentAccumulatorStep(),
         this->getAccumulatorNumberOfSteps(),
         coarseFrequencyChannelOffset[0],
@@ -238,12 +239,14 @@ const Result ModeS<HT>::accumulate(const ArrayTensor<Device::CUDA, F32>& data,
     if (this->getAccumulatorNumberOfSteps() == 1) {
         BL_CHECK(Memory::Copy(
             this->prebeamformerData,
-            prebeamformerData
+            prebeamformerData,
+            stream
         ));
         
         BL_CHECK(Memory::Copy(
             this->input,
-            data
+            data,
+            stream
         ));
     }
     else {
@@ -292,7 +295,7 @@ const Result ModeS<HT>::accumulate(const ArrayTensor<Device::CUDA, F32>& data,
     }
 
     BL_DEBUG(
-        "accumulate from CUDA: {}/{}\nschan: {}\nfch1: {}\njd: {}",
+        "accumulate from VRAM: {}/{}\nschan: {}\nfch1: {}\njd: {}",
         this->getCurrentAccumulatorStep(),
         this->getAccumulatorNumberOfSteps(),
         coarseFrequencyChannelOffset[0],

--- a/src/pipelines/generic/mode_s.cc
+++ b/src/pipelines/generic/mode_s.cc
@@ -59,6 +59,8 @@ ModeS<HT>::ModeS(const Config& config)
         .aspectCoordinates = config.beamCoordinates,
         .totalNumberOfTimeSamples = config.inputTotalNumberOfTimeSamples,
         .totalNumberOfFrequencyChannels = config.inputTotalNumberOfFrequencyChannels,
+
+        .produceDebugHits = config.produceDebugHits,
     }, {
         .buf = this->input,
         .coarseFrequencyChannelOffset = this->coarseFrequencyChannelOffset,
@@ -78,6 +80,8 @@ ModeS<HT>::ModeS(const Config& config)
             .coarseChannelRatio = config.inputCoarseChannelRatio,
             .channelBandwidthHz = config.searchChannelBandwidthHz,
             .channelTimespanS = config.searchChannelTimespanS,
+            .stampFrequencyMarginHz = config.produceDebugHits ? 0.0 : config.searchStampFrequencyMarginHz,
+            .hitsGroupingMargin = config.produceDebugHits ? -config.inputCoarseChannelRatio : config.searchHitsGroupingMargin,
             .excludeDriftRateZero = config.searchDriftRateZeroExcluded,
         }, {
             .buffer = this->prebeamformerData,
@@ -98,6 +102,8 @@ ModeS<HT>::ModeS(const Config& config)
             .coarseChannelRatio = config.inputCoarseChannelRatio,
             .channelBandwidthHz = config.searchChannelBandwidthHz,
             .channelTimespanS = config.searchChannelTimespanS,
+            .stampFrequencyMarginHz = config.produceDebugHits ? 0.0 : config.searchStampFrequencyMarginHz,
+            .hitsGroupingMargin = config.produceDebugHits ? -config.inputCoarseChannelRatio : config.searchHitsGroupingMargin,
             .excludeDriftRateZero = config.searchDriftRateZeroExcluded,
         }, {
             .buffer = this->prebeamformerData,


### PR DESCRIPTION
The dedoppler search buffer is collated in RAM (as opposed to VRAM) and is always exhaustive of all fine-spectra.

Multiple fixes and improvements.